### PR TITLE
Update nrfxlib to 2.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrfxlib-sys"
-version = "2.7.1"
+version = "2.9.1"
 authors = [
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
 	"42 Technology Ltd <jonathan.pallant@42technology.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ llvm-tools = { version = "0.1.1", optional = true }
 default = ["llvm-objcopy"]
 arm-none-eabi-objcopy = []
 llvm-objcopy = ["dep:llvm-tools"]
+log = []
 
 nrf9160 = []
 nrf9151 = ["nrf9120"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In your own program or library, you can depend on this crate in the usual fashio
 ```toml
 [dependencies]
 # A chip feature must be selected
-nrfxlib-sys = { version = "=2.7.1", features = ["nrf9160"] }
+nrfxlib-sys = { version = "=2.9.1", features = ["nrf9160"] }
 ```
 
 Because the modem library has its debug sections compressed and Rust's tooling doesn't have support for
@@ -72,7 +72,12 @@ without any additional terms or conditions.
 
 ## Changelog
 
-### Unreleased Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/develop) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.4.2...develop))
+### Unreleased Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/develop) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.9.1...develop))
+
+### v2.9.1 ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/v2.9.1) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.7.1...v2.9.1))
+
+* Updated to [nrfxlib v2.9.1](https://github.com/NordicPlayground/nrfxlib/tree/v2.9.1)
+* Added feature `log` for including the binary blobs with logging support.
 
 ### v2.7.1 ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/v2.7.1) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.4.2...v2.7.1))
 

--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,7 @@ fn main() {
 		.clang_arg("-I./third_party/nordic/nrfxlib/crypto/nrf_cc310_platform/include")
 		.clang_arg("-I./third_party/nordic/nrfxlib/crypto/nrf_cc310_mbedcrypto/include")
 		.clang_arg("-I./third_party/nordic/nrfxlib/crypto/nrf_oberon")
+		.clang_arg("-I./third_party/nordic/nrfxlib/nrf_modem/include")
 		// Disable standard includes (they belong to the host)
 		.clang_arg("-nostdinc")
 		// Set the target

--- a/build.rs
+++ b/build.rs
@@ -95,12 +95,18 @@ fn main() {
 	std::fs::write(bindings_out_path, rust_source).expect("Couldn't write updated bindgen output");
 
 	#[cfg(feature = "nrf9160")]
-	let libmodem_original_path =
-		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9160/hard-float/libmodem.a");
+	let libmodem_original_path = if cfg!(feature = "log") {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9160/hard-float/libmodem_log.a")
+	} else {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9160/hard-float/libmodem.a")
+	};
 
 	#[cfg(feature = "nrf9120")]
-	let libmodem_original_path =
-		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9120/hard-float/libmodem.a");
+	let libmodem_original_path = if cfg!(feature = "log") {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9120/hard-float/libmodem_log.a")
+	} else {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9120/hard-float/libmodem.a")
+	};
 
 	let libmodem_changed_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("libmodem.a");
 


### PR DESCRIPTION
I've used this branch to test the change:

https://github.com/jue89/nrf-modem/tree/bump-nrfxlib-sys

I also added a `log` feature to include Nordic's binary with logging enabled.