### PR TITLE
Fix docs.rs builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrfxlib-sys"
-version = "2.9.1"
+version = "2.9.2"
 authors = [
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
 	"42 Technology Ltd <jonathan.pallant@42technology.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ include = [
 	"third_party/nordic/nrfxlib/crypto/nrf_oberon/license.txt",
 ]
 
+[package.metadata.docs.rs]
+features = ["nrf9160"]
+
 [dependencies]
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ without any additional terms or conditions.
 
 ## Changelog
 
-### Unreleased Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/develop) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.9.1...develop))
+### Unreleased Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/develop) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.9.2...develop))
+
+### v2.9.2 ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/v2.9.2) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.9.1...v2.9.2))
+
+* Disabled bindgen layout tests so this crate can be built for desktops
+* Selected a chip feature so docs can be build again
 
 ### v2.9.1 ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/v2.9.1) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.7.1...v2.9.1))
 

--- a/build.rs
+++ b/build.rs
@@ -58,6 +58,8 @@ fn main() {
 		.allowlist_var("OCRYPTO_.*")
 		// Format the output
 		.formatter(bindgen::Formatter::Rustfmt)
+		// Disable so it can build on desktop too
+		.layout_tests(false)
 		// Finish the builder and generate the bindings.
 		.generate()
 		// Unwrap the Result and panic on failure.


### PR DESCRIPTION
Kia ora all,

The docs.rs builds have been [failing](https://docs.rs/crate/nrfxlib-sys/2.9.1/builds/1905285) for a while now.

This PR specifies docs.rs builds should be built with the a device feature enabled (as described [here](https://docs.rs/about/metadata)), otherwise the build will fail. It's my understanding that the user-facing API is very similar between chips so the docs should still be applicable to the others.

I've also noticed the docs are failing for `nrf-modem` but this seems to be a different problem? I'll open a separate issue there.

Let me know if this is ok, it's just my best-effort guess at a fix.