### PR TITLE
Update nrfxlib to 3.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrfxlib-sys"
-version = "2.9.2"
+version = "3.0.2"
 authors = [
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
 	"42 Technology Ltd <jonathan.pallant@42technology.com>",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In your own program or library, you can depend on this crate in the usual fashio
 ```toml
 [dependencies]
 # A chip feature must be selected
-nrfxlib-sys = { version = "=2.9.1", features = ["nrf9160"] }
+nrfxlib-sys = { version = "=3.0.2", features = ["nrf9160"] }
 ```
 
 Because the modem library has its debug sections compressed and Rust's tooling doesn't have support for
@@ -73,6 +73,8 @@ without any additional terms or conditions.
 ## Changelog
 
 ### Unreleased Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/develop) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.9.2...develop))
+
+* Updated to [nrfxlib v3.0.2](https://github.com/NordicPlayground/nrfxlib/tree/v3.0.2)
 
 ### v2.9.2 ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/v2.9.2) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.9.1...v2.9.2))
 

--- a/build.rs
+++ b/build.rs
@@ -173,6 +173,6 @@ fn main() {
 			.display()
 	);
 	println!("cargo:rustc-link-lib=static=modem");
-	println!("cargo:rustc-link-lib=static=oberon_3.0.15");
+	println!("cargo:rustc-link-lib=static=oberon_3.0.16");
 	println!("cargo:rustc-link-lib=static=nrf_cc310_platform_0.9.19");
 }

--- a/wrapper.h
+++ b/wrapper.h
@@ -35,20 +35,17 @@
  */
 
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/aes_alt.h"
+/* #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/cc3xx_kmu.h" depends on mbedtls/config.h */
+/* #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/ccm_alt.h" depends on config cipher.h */
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/chacha20_alt.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/chachapoly_alt.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/cmac_alt.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/dhm_alt.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/ecp_alt.h"
-#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/platform_alt.h"
-#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/poly1305_alt.h"
-#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/rsa_alt.h"
-#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/sha1_alt.h"
-#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/sha256_alt.h"
-#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/threading_alt.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_aes_defs.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_aes_defs_proj.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_bitops.h"
+/* #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_ecpki_types.h" depends on config cc_pka_hw_plat_defs.h via cc_pka_defs_hw.h */
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_error.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_hash_defs.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_hash_defs_proj.h"
@@ -56,14 +53,22 @@
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_pal_compiler.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_pal_types.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_pal_types_plat.h"
+/* #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_pka_defs_hw.h" depends on config cc_pka_hw_plat_defs.h */
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_rnd_common.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/cc_rnd_error.h"
-#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/mbedtls_cc_aes_key_wrap.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/mbedtls_cc_aes_key_wrap_error.h"
+#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/mbedtls_cc_aes_key_wrap.h"
+/* #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/mbedtls_cc_ecies.h" depends on config cc_pka_hw_plat_defs.h via cc_pka_defs_hw.h */
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/mbedtls_cc_ec_mont_edw_error.h"
-#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/mbedtls_cc_hkdf.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/mbedtls_cc_hkdf_error.h"
+#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/mbedtls_cc_hkdf.h"
 #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/mbedtls_cc_srp_error.h"
+/* #include "crypto/nrf_cc310_mbedcrypto/include/mbedtls_extra/mbedtls_cc_srp.h" depends on config cc_pka_hw_plat_defs.h via cc_pka_defs_hw.h */
+#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/platform_alt.h"
+#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/poly1305_alt.h"
+#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/rsa_alt.h"
+#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/sha1_alt.h"
+#include "crypto/nrf_cc310_mbedcrypto/include/mbedtls/sha256_alt.h"
 
 /*
  * In addition to CC310 acceleration for mbedTLS, this repository also appears


### PR DESCRIPTION
mbedtls headers changed a lot; all are listed, but some that depend on build-time configuration are explicitly commented out. I left them in there because I expect that next time mbed is updated, someone will like me populate this from `ls .../*/*.h` and then sift through what works and what not.

---

I couldn't really test this yet, because I'm working with the DECT network-core firmware, exposing which is probably a follow-up. I hope the changes in here are useful at least as a starting point for if/when someone wants to use the more established (and thus testable) features of this crate with the later version.