### PR TITLE
Make the DECT-2020 NR+ libmodem.a available as well

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -110,7 +110,23 @@ fn main() {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9120/hard-float/libmodem.a")
 	};
 
+	#[cfg(feature = "nrf9160")]
+	let libmodemdect_original_path = if cfg!(feature = "log") {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9160/hard-float/libmodem_log.a")
+	} else {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9160/hard-float/libmodem.a")
+	};
+
+	#[cfg(feature = "nrf9120")]
+	let libmodemdect_original_path = if cfg!(feature = "log") {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem_log.a")
+	} else {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem.a")
+	};
+
 	let libmodem_changed_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("libmodem.a");
+	let libmodemdect_changed_path =
+		PathBuf::from(env::var("OUT_DIR").unwrap()).join("libmodem_dect.a");
 
 	// The modem library now has compressed headers, but Rust cannot deal with that.
 	// If the appropriate features is active, we're gonna strip it or decompress it.
@@ -141,10 +157,22 @@ fn main() {
 			.tool(&llvm_tools::exe("llvm-objcopy"))
 			.expect(tool_error);
 
-		let child = std::process::Command::new(path)
+		let child = std::process::Command::new(&path)
 			.arg("--strip-debug")
 			.arg(&libmodem_original_path)
 			.arg(&libmodem_changed_path)
+			.spawn()
+			.expect(tool_error);
+
+		let child_result = child.wait_with_output().unwrap();
+		if !child_result.status.success() {
+			panic!("Something went wrong with `llvm-objcopy`.");
+		}
+
+		let child = std::process::Command::new(&path)
+			.arg("--strip-debug")
+			.arg(&libmodemdect_original_path)
+			.arg(&libmodemdect_changed_path)
 			.spawn()
 			.expect(tool_error);
 
@@ -173,6 +201,7 @@ fn main() {
 			.display()
 	);
 	println!("cargo:rustc-link-lib=static=modem");
+	println!("cargo:rustc-link-lib=static=modem_dect");
 	println!("cargo:rustc-link-lib=static=oberon_3.0.16");
 	println!("cargo:rustc-link-lib=static=nrf_cc310_platform_0.9.19");
 }

--- a/wrapper.h
+++ b/wrapper.h
@@ -15,6 +15,7 @@
 #include "nrf_modem/include/nrf_modem_bootloader.h"
 #include "nrf_modem/include/nrf_modem_trace.h"
 #include "nrf_modem/include/nrf_gai_errors.h"
+#include "nrf_modem/include/nrf_modem_dect_phy.h"
 
 /*
  * Crypto Cell 310 (CC310) platform headers


### PR DESCRIPTION
A part of libmodem is the DECT PHY interface; this PR includes the library.

The DECT part is currently hard to test because the radio core firmware is only available on request; while [the nascent hophop docs](https://github.com/ariel-os/hophop/blob/main/doc/dect-firmware.md) describe how to flash it, "you must contact the Nordic Semiconductor sales department" to get the actual zip file.

I yet have to assemble an application with which this could be tested by those who have the firmware image, hence the "draft" status. Until then, questions to discuss are:

* Do we expect more libraries to require the cleanup step? (Then what is now code copy-paste could become a loop.)
* Would this be an acceptable pull request before the DECT firmware is made available to the general public, or devkits can be bought that have it flashed off the shelf?