### PR TITLE
Make the DECT-2020 NR+ libmodem.a available as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,14 @@ arm-none-eabi-objcopy = []
 llvm-objcopy = ["dep:llvm-tools"]
 log = []
 
+## Links the DECT modem library
+##
+## This exposes the same set of headers, but internally uses a different
+## libmodem.a library, which is used with considerable differences. Note that
+## using this also requires using an alternative radio core firmware, which is
+## not shipped in crates.
+dect = []
+
 nrf9160 = []
 nrf9151 = ["nrf9120"]
 nrf9161 = ["nrf9120"]

--- a/build.rs
+++ b/build.rs
@@ -45,6 +45,8 @@ fn main() {
 		.clang_arg("-mcpu=cortex-m33")
 		// Use softfp
 		.clang_arg("-mfloat-abi=soft")
+		// Enum types are short, eg. nrf_modem_dect_phy_err is 16bit
+		.clang_arg("-fshort-enums")
 		// We're no_std
 		.use_core()
 		// Include only the useful stuff

--- a/build.rs
+++ b/build.rs
@@ -96,18 +96,32 @@ fn main() {
 	let bindings_out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
 	std::fs::write(bindings_out_path, rust_source).expect("Couldn't write updated bindgen output");
 
-	#[cfg(feature = "nrf9160")]
+	#[cfg(all(feature = "nrf9160", not(feature = "dect")))]
 	let libmodem_original_path = if cfg!(feature = "log") {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9160/hard-float/libmodem_log.a")
 	} else {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9160/hard-float/libmodem.a")
 	};
 
-	#[cfg(feature = "nrf9120")]
+	#[cfg(all(feature = "nrf9120", not(feature = "dect")))]
 	let libmodem_original_path = if cfg!(feature = "log") {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9120/hard-float/libmodem_log.a")
 	} else {
 		Path::new(&nrfxlib_path).join("nrf_modem/lib/cellular/nrf9120/hard-float/libmodem.a")
+	};
+
+	#[cfg(all(feature = "nrf9160", feature = "dect"))]
+	let libmodem_original_path = if cfg!(feature = "log") {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9160/hard-float/libmodem_log.a")
+	} else {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9160/hard-float/libmodem.a")
+	};
+
+	#[cfg(all(feature = "nrf9120", feature = "dect"))]
+	let libmodem_original_path = if cfg!(feature = "log") {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem_log.a")
+	} else {
+		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem.a")
 	};
 
 	let libmodem_changed_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("libmodem.a");

--- a/wrapper.h
+++ b/wrapper.h
@@ -15,6 +15,7 @@
 #include "nrf_modem/include/nrf_modem_bootloader.h"
 #include "nrf_modem/include/nrf_modem_trace.h"
 #include "nrf_modem/include/nrf_gai_errors.h"
+#include "nrf_modem/include/nrf_modem_dect_phy.h"
 
 /*
  * Crypto Cell 310 (CC310) platform headers


### PR DESCRIPTION
This is a do-over of #15 after moving towards a testable application with nrf-modem.

Unlike the original approach it *switches* (rather than adding) the library; consequently, this needs to be feature-gated to keep the library usable. (The original idea with #15 was to just always link both, let the user decide what they reference and the linker what to gc, but actually the different libmodem.a have different texts for identical symbols).

How much this is additive (as features should be) I can not tell because I don't see into the proprietary libraries, but I guess that using DECT will break the other cases. But we're in low-level embedded crates, and feature additivity is generally not valued so much when there's already a hard decision for which chip is to be selected.

The issue remains that for this to be practically releasable, a firmware would need to be available.

---

An extra commit switches on short enums. It remains to be tested whether the radio libmodem is built this way as well.