### PR TITLE
DECT: Ship libmodem.a in crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ include = [
 	"third_party/nordic/nrfxlib/nrf_modem/lib/cellular/nrf9160/hard-float/libmodem_log.a",
 	"third_party/nordic/nrfxlib/nrf_modem/lib/cellular/nrf9120/hard-float/libmodem.a",
 	"third_party/nordic/nrfxlib/nrf_modem/lib/cellular/nrf9120/hard-float/libmodem_log.a",
+	"third_party/nordic/nrfxlib/nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem.a",
+	"third_party/nordic/nrfxlib/nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem_log.a",
 	"third_party/nordic/nrfxlib/nrf_modem/include/**",
 	"third_party/nordic/nrfxlib/nrf_modem/license.txt",
 	"third_party/nordic/nrfxlib/nrf_modem/README.rst",

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ without any additional terms or conditions.
 
 ### Unreleased Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/develop) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v3.0.2...develop))
 
+* Include static files for DECT in the published crate. (fixing [#18](https://github.com/nrf-rs/nrfxlib-sys/pull/18))
+
 ### v3.0.2 ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/v3.0.2) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.9.2...v3.0.2))
 
 * Updated to [nrfxlib v3.0.2](https://github.com/NordicPlayground/nrfxlib/tree/v3.0.2)

--- a/build.rs
+++ b/build.rs
@@ -113,11 +113,7 @@ fn main() {
 	};
 
 	#[cfg(all(feature = "nrf9160", feature = "dect"))]
-	let libmodem_original_path = if cfg!(feature = "log") {
-		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9160/hard-float/libmodem_log.a")
-	} else {
-		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9160/hard-float/libmodem.a")
-	};
+	panic!("The DECT library is not available for the nRF9160 series.");
 
 	#[cfg(all(feature = "nrf9120", feature = "dect"))]
 	let libmodem_original_path = if cfg!(feature = "log") {


### PR DESCRIPTION
The published version 3.0.2 doesn't work for DECT: I missed that the .a file needs to be listed in Cargo.toml -- and that didn't show in tests because before a release, I could not test with a published crate. (Short of uploading to the test instance of crates.io, that is).

Fixing this has also shown that a combination that I didn't test for lack of hardware doesn't even have the file; the build script now errs out with a suitable message rather than trying to access a file we don't have.

Practically, with the nrfxlib-sys versions tracking the upstream ones 1:1: Can we publish this in any way? (In Debian we'd always have 3.0.2-1 and could do a -2, but that's not how Rust's semver versions work). Or do we just sidestep the issue and I do an update to 3.2.2 as well? (I don't need it, but I do guess there is someone who will find it useful).