### PR TITLE
Switch versioning scheme, release v3.0.3+3.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrfxlib-sys"
-version = "3.0.2"
+version = "3.0.3+3.0.2"
 authors = [
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
 	"42 Technology Ltd <jonathan.pallant@42technology.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ include = [
 	"third_party/nordic/nrfxlib/nrf_modem/lib/cellular/nrf9160/hard-float/libmodem_log.a",
 	"third_party/nordic/nrfxlib/nrf_modem/lib/cellular/nrf9120/hard-float/libmodem.a",
 	"third_party/nordic/nrfxlib/nrf_modem/lib/cellular/nrf9120/hard-float/libmodem_log.a",
+	"third_party/nordic/nrfxlib/nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem.a",
+	"third_party/nordic/nrfxlib/nrf_modem/lib/dect_phy/nrf9120/hard-float/libmodem_log.a",
 	"third_party/nordic/nrfxlib/nrf_modem/include/**",
 	"third_party/nordic/nrfxlib/nrf_modem/license.txt",
 	"third_party/nordic/nrfxlib/nrf_modem/README.rst",

--- a/README.md
+++ b/README.md
@@ -24,14 +24,12 @@ please - for now I'm using
 
 ## Using
 
-**NOTE**: This crate does **not** follow [semver](https://doc.rust-lang.org/cargo/reference/semver.html). The version of this crate tracks the version of the underlying Nordic [libraries](https://github.com/nrfconnect/sdk-nrfxlib/tags).
-
 In your own program or library, you can depend on this crate in the usual fashion:
 
 ```toml
 [dependencies]
 # A chip feature must be selected
-nrfxlib-sys = { version = "=3.0.2", features = ["nrf9160"] }
+nrfxlib-sys = { version = "3.0.2", features = ["nrf9160"] }
 ```
 
 Because the modem library has its debug sections compressed and Rust's tooling doesn't have support for
@@ -58,6 +56,15 @@ You might also prefer the async [higher-level wrapper](https://crates.io/crates/
 nrf-modem = "*"
 ```
 
+### Versions
+
+The underlying Nordic
+[libraries](https://github.com/nrfconnect/sdk-nrfxlib/tags) are not versioned
+according to [Rust's semver](https://doc.rust-lang.org/cargo/reference/semver.html) conventions.
+<!-- evidence is eg. the removal of the sa_len fields in 2.5.0 -->
+Recent versions of this crate adhere to semver to the best of the maintainers' understanding,
+and pack the upstream version in the build metadata (i.e., after the `+` sign).
+
 ## Licence
 
 Any of the code outside the `./third_party` folder is under the [Blue Oak
@@ -74,6 +81,7 @@ without any additional terms or conditions.
 
 ### Unreleased Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/develop) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v3.0.2...develop))
 
+* Changed versioning to separate own semver version from upstream library version.
 * Include static files for DECT in the published crate. (fixing [#18](https://github.com/nrf-rs/nrfxlib-sys/pull/18))
 
 ### v3.0.2 ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/v3.0.2) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.9.2...v3.0.2))

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ without any additional terms or conditions.
 
 ## Changelog
 
-### Unreleased Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/develop) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v3.0.2...develop))
+### Unreleased Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/develop) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v3.0.3+3.0.2...develop))
+
+### v3.0.3+3.0.2 Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/v3.0.3+3.0.2) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v3.0.2...v3.0.3+3.0.2))
 
 * Changed versioning to separate own semver version from upstream library version.
 * Include static files for DECT in the published crate. (fixing [#18](https://github.com/nrf-rs/nrfxlib-sys/pull/18))

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ without any additional terms or conditions.
 
 ### Unreleased Changes ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/develop) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v3.0.2...develop))
 
+* Include static files for DECT in the published crate. (fixing [#18](https://github.com/nrf-rs/nrfxlib-sys/pull/18))
+
 ### v3.0.2 ([Source](https://github.com/nrf-rs/nrfxlib-sys/tree/v3.0.2) | [Changes](https://github.com/nrf-rs/nrfxlib-sys/compare/v2.9.2...v3.0.2))
 
 * Updated to [nrfxlib v3.0.2](https://github.com/NordicPlayground/nrfxlib/tree/v3.0.2)

--- a/build.rs
+++ b/build.rs
@@ -113,11 +113,7 @@ fn main() {
 	};
 
 	#[cfg(all(feature = "nrf9160", feature = "dect"))]
-	let libmodem_original_path = if cfg!(feature = "log") {
-		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9160/hard-float/libmodem_log.a")
-	} else {
-		Path::new(&nrfxlib_path).join("nrf_modem/lib/dect_phy/nrf9160/hard-float/libmodem.a")
-	};
+	panic!("The DECT library is not available for the nRF9160 series.");
 
 	#[cfg(all(feature = "nrf9120", feature = "dect"))]
 	let libmodem_original_path = if cfg!(feature = "log") {


### PR DESCRIPTION
(This is based on #18 to avoid tedious rebasing; please ignore the first 3 commits.)

As discussed in https://github.com/nrf-rs/nrfxlib-sys/pull/18, a libgit2-sys style versioning scheme makes sense: We're not shipping all of nrfxlib-sys (just a subset, libmodem and liboberon), so removals of APIs we don't expose "don't count", and we're doing Rust wrappers, so some signature changes that are compatible in C but incompatible in Rust do count (ask me how I know…). Plus upstream isn't semver anyway.

(Also, it conveniently provides the version bump we couldn't otherwise do to fix #18).

The downside of this is that we'll have to look at the change logs to assess whether a change is breaking or not, but I think that's within scope of providing a -sys crate.